### PR TITLE
fix cicd

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-asyncio
-version = attr: pytest_asyncio.__version__
+version = attr: pytest_asyncio._version.version
 url = https://github.com/pytest-dev/pytest-asyncio
 project_urls =
   GitHub = https://github.com/pytest-dev/pytest-asyncio


### PR DESCRIPTION
https://modal-com.slack.com/archives/C087VMPHL5Q/p1755387480535559

This make `uv pip install -e .` work by allowing the version to be read by AST parsing instead of importing `__version__.py`